### PR TITLE
travis: do no optimisation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ install:
   
 script: 
   - ./boost.sh
-  - ./build.sh CFLAGS="-Os -s"
+  - ./build.sh CFLAGS="-s"


### PR DESCRIPTION
Reduces build time on Travis CI [by several minutes](https://travis-ci.org/veox/libbitcoin_explorer/builds/34297710). The run has not finished as of this writing, and I can see it won't make it, but this is an improvement.

I initially did the test on `master`, [here's the same](https://travis-ci.org/veox/libbitcoin_explorer/builds/34300723) on `develop` (also not finished as of this writing).

Perhaps a further optimisation is possible by using the [boost-latest PPA](https://launchpad.net/~boost-latest/+archive/ubuntu/ppa), but haven't tried it yet.

Most of the time is still taken up by building the toolchain, so the optimisations should probably be done by using Travis' tools.
