### PR TITLE
Make tests a configuration parameter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -329,6 +329,7 @@ bx_LDADD = \
 #
 # tests
 #
+if ENABLE_TESTS
 TESTS = test/libbitcoin_explorer_test
 
 check_PROGRAMS = test/libbitcoin_explorer_test
@@ -446,3 +447,5 @@ test_libbitcoin_explorer_test_LDADD = \
     -lboost_chrono \
     -lboost_program_options \
     ${bitcoin_client_LIBS}
+endif
+

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,6 @@ AX_BOOST_FILESYSTEM
 AX_BOOST_PROGRAM_OPTIONS
 AX_BOOST_REGEX
 AX_BOOST_SYSTEM
-AX_BOOST_UNIT_TEST_FRAMEWORK
 
 # GMP does not publish a package config, so we do a header and library test.
 AC_CHECK_HEADER(gmp.h,,
@@ -36,6 +35,19 @@ PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([bitcoin], [libbitcoin >= 2.5.0])
 PKG_CHECK_MODULES([bitcoin_client], [libbitcoin-client >= 0.1.0])
 PKG_CHECK_MODULES([sodium], [libsodium >= 0.6.0])
+
+# build tests
+AC_ARG_WITH([tests], [AS_HELP_STRING([--with-tests],
+    [require build with tests. Requires pkg-config [default=no]])],
+    [enable_tests_ext=$withval],
+    [enable_tests_ext=no])
+
+# conditionally require test dependencies
+if test "x$enable_tests_ext" != "xno"; then
+    AX_BOOST_UNIT_TEST_FRAMEWORK
+fi
+
+AM_CONDITIONAL(ENABLE_TESTS, test "x$enable_tests_ext" != "xno")
 
 AC_DEFINE(BOOST_NO_EXCEPTIONS)
 AC_DEFINE(BOOST_EXCEPTION_DISABLE)

--- a/install-bx.sh
+++ b/install-bx.sh
@@ -23,6 +23,10 @@ BUILD_ACCOUNT="libbitcoin"
 BUILD_REPO="libbitcoin-explorer"
 BUILD_BRANCH="master"
 
+# enable testing
+TEST_OPTIONS=\
+"--with-tests=yes"
+
 # https://github.com/bitcoin/secp256k1
 SECP256K1_OPTIONS=\
 "--with-bignum=gmp "\
@@ -181,7 +185,7 @@ build_library()
     build_from_github libbitcoin libbitcoin-client master "$PARALLEL" "$@"
 
     # The primary build is not downloaded if we are running in Travis.
-    build_primary "$PARALLEL" "$@"
+    build_primary "$PARALLEL" "$@" $TEST_OPTIONS
 
     # If the build succeeded clean up the build directory.
     delete_build_directory

--- a/model/generate.gsl
+++ b/model/generate.gsl
@@ -1284,6 +1284,7 @@ bx_LDADD = \\
 #
 # tests
 #
+if ENABLE_TESTS
 TESTS = test/libbitcoin_explorer_test
 
 check_PROGRAMS = test/libbitcoin_explorer_test
@@ -1316,6 +1317,8 @@ test_libbitcoin_explorer_test_LDADD = \\
     -lboost_chrono \\
     -lboost_program_options \\
     ${bitcoin_client_LIBS}
+endif
+
 .##############################################################################
 .echo "Generating builds/msvc/vs2013/libbitcoin-explorer/libbitcoin-explorer.vcxproj..."
 .output "../builds/msvc/vs2013/libbitcoin-explorer/libbitcoin-explorer.vcxproj"


### PR DESCRIPTION
Enable tests via --with-tests configuration parameter, allowing test-only dependencies to be ignored for the purposes of installation.
