### PR TITLE
need "sudo" before "make install"

### DIFF
--- a/install-bx.sh
+++ b/install-bx.sh
@@ -237,7 +237,7 @@ make_current_directory()
     ./autogen.sh
     configure_options "$@"
     make_silent $JOBS
-    make install
+    sudo make install
 
     # Use ldconfig only in case of non --prefix installation on Linux.    
     if [[ ($OS == "Linux") && !($PREFIX)]]; then
@@ -324,7 +324,7 @@ build_from_tarball_gmp()
     # GMP does not provide autogen.sh or package config.
     configure_options "$@"
     make_silent $JOBS
-    make install
+    sudo make install
 
     popd
 }


### PR DESCRIPTION
This script only runs for me on Ubuntu 14.04 with sudo bash install-bx.sh
I added sudo before "make install" and seems to work now on fresh Ubuntu 14.04 install.
