### PR TITLE
fix display_linkage() - errors without prefix

### DIFF
--- a/install-bx.sh
+++ b/install-bx.sh
@@ -210,7 +210,7 @@ display_linkage()
     if [[ $OS == "Darwin" ]]; then
         otool -L $LIBRARY
     else
-        ldd --verbose $LIBRARY
+        ldd --verbose `which $LIBRARY`
     fi
 }
 


### PR DESCRIPTION
tl;dr:  install script on ubuntu 14.04 exits with error near the end:  "ldd: ./bx: No such file or directory"
Tracking this down, it is from the "ldd --verbose bx" call in display_linkage. (I did not use a prefix).

on ubuntu 14.04, fresh install, the install script works perfectly up until the call to "demonstrate_library" near the end which calls display_linkage. The end of my output from the "sudo bash install-bx.sh" follows:
# PASS: run-tests.sh
# Testsuite summary for libitcoin-explorer 2.0.0
# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
# 

~/SX/src2/bx-build ~/SX/src2
~/SX/src2
settings
{
    general
    {
        network mainnet
        retries 0
        wait 2000
    }
    mainnet
    {
        url tcp://obelisk.airbitz.co:9091
    }
    testnet
    {
        url tcp://obelisk-testnet.airbitz.co:9091
    }
}

ldd: ./bx: No such file or directory
###### 

Me: When not specifying a prefix, $1 is just "bx" and despite "bx" being in my PATH, ("which bx" works fine e.g.), the call to "ldd --verbose bx" fails (you can try this now, even with bx discoverable in your usual PATH). 

$ ldd --verbose bx
ldd: ./bx: No such file or directory

$ which bx
/usr/local/bin/bx

$ ldd --verbose `which bx`
    linux-vdso.so.1 =>  (0x00007fff70bfc000) .. and so on, successfully

This PR assumes that with no prefix set, "bx" is discoverable in your PATH. (/usr/local/bin is in PATH).

Just wanted to make this very minor fix.
