### PR TITLE
Add bash completion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ libbitcoin-explorer.pc
 .cproject
 .project
 
+/bx
 /obj/
 /bin/
 /bx-build/

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,12 @@ doc_DATA = README INSTALL COPYING
 #
 pkgconfig_DATA = libbitcoin-explorer.pc
 
+# bash completion
+if ENABLE_BASH_COMPLETION
+bashcompletiondir = $(BASH_COMPLETION_DIR)
+dist_bashcompletion_DATA = data/bx
+endif
+
 # look for macros in the m4 subdirectory
 ACLOCAL_AMFLAGS = -I m4
 

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,16 @@ AC_ARG_WITH([tests],
     [with_tests=yes])
 AC_MSG_RESULT($with_tests)
 
+# Support --with-bash-completion-dir option
+#------------------------------------------------------------------------------
+AC_MSG_CHECKING(--with-bash-completion-dir option)
+AC_ARG_WITH([bash-completion-dir],
+    AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
+        [Install the bash auto-completion script in this directory. @<:@default=yes@:>@]),
+    [],
+    [with_bash_completion_dir=yes])
+AC_MSG_RESULT($with_bash_completion_dir)
+
 # Require boost min version.
 #------------------------------------------------------------------------------
 # Boost does not publish package configs but has m4 tests.
@@ -132,6 +142,19 @@ AM_COND_IF([WITH_TESTS], [AC_MSG_NOTICE([WITH_TESTS defined])])
 AM_CONDITIONAL([SET_BOOST_TEST_DYN_LINK], [test x$enable_shared != xno])
 AM_COND_IF([SET_BOOST_TEST_DYN_LINK],
     [AC_MSG_NOTICE([BOOST_TEST_DYN_LINK defined])])
+
+# Make use of bash completion if $with_bash_completion_dir is set.
+#------------------------------------------------------------------------------
+if test "x$with_bash_completion_dir" = "xyes"; then
+    PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
+        [BASH_COMPLETION_DIR="`pkg-config --variable=completionsdir bash-completion`"],
+        [BASH_COMPLETION_DIR="$datadir/bash-completion/completions"])
+else
+    BASH_COMPLETION_DIR="$with_bash_completion_dir"
+fi
+
+AC_SUBST([BASH_COMPLETION_DIR])
+AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion_dir" != "xno"])
 
 # Set warning levels.
 #------------------------------------------------------------------------------

--- a/data/bx
+++ b/data/bx
@@ -1,0 +1,113 @@
+#
+#  Command-line completion for bx
+#
+_bx()
+{
+    local current="${COMP_WORDS[COMP_CWORD]}"
+    local commands="
+        address-decode
+        address-embed
+        address-encode
+        address-validate
+        base16-decode
+        base16-encode
+        base58-decode
+        base58-encode
+        base58check-decode
+        base58check-encode
+        bci-fetch-last-height
+        bci-history
+        bitcoin160
+        bitcoin256
+        blke-fetch-transaction
+        btc-to-satoshi
+        ec-add
+        ec-add-secrets
+        ec-lock
+        ec-multiply
+        ec-multiply-secrets
+        ec-new
+        ec-to-address
+        ec-to-public
+        ec-to-wif
+        ec-unlock
+        fetch-balance
+        fetch-header
+        fetch-height
+        fetch-history
+        fetch-public-key
+        fetch-stealth
+        fetch-tx
+        fetch-tx-index
+        fetch-utxo
+        genaddr
+        genpriv
+        genpub
+        hd-new
+        hd-private
+        hd-public
+        hd-to-address
+        hd-to-ec
+        hd-to-public
+        hd-to-wif
+        help
+        initchain
+        input-set
+        input-sign
+        input-validate
+        mnemonic-decode
+        mnemonic-encode
+        mpk
+        newseed
+        qrcode
+        ripemd160
+        satoshi-to-btc
+        script-decode
+        script-encode
+        script-to-address
+        seed
+        send-tx
+        send-tx-node
+        send-tx-p2p
+        sendtx-bci
+        settings
+        sha160
+        sha256
+        sha512
+        showblkhead
+        stealth-decode
+        stealth-encode
+        stealth-initiate
+        stealth-newkey
+        stealth-public
+        stealth-secret
+        stealth-shared
+        tx-decode
+        tx-encode
+        tx-sign
+        uri-decode
+        uri-encode
+        validate-tx
+        wallet
+        watch-address
+        watch-tx
+        wif-to-ec
+        wif-to-public
+        wrap-decode
+        wrap-encode
+    "
+
+    if [ $COMP_CWORD -eq 1 ]; then
+        COMPREPLY=( $(compgen -W "$commands" -- $current) )
+        return
+    fi
+
+    local command=COMP_WORDS[1]
+    local options="--config --help -c -h"
+
+    # TODO: Generate per-command options here
+
+    COMPREPLY=( $(compgen -W "$options" -- $current) )
+}
+complete -F _bx bx
+

--- a/model/generate
+++ b/model/generate
@@ -1,6 +1,7 @@
 #   Run code generation
 #   Requires iMatix GSL, from http://github.com/imatix/gsl
 
+mkdir -p ../data
 mkdir -p ../src/commands
 mkdir -p ../include/bitcoin/explorer/commands
 

--- a/model/generate.bat
+++ b/model/generate.bat
@@ -2,6 +2,7 @@
 REM   Run all code generation scripts
 REM   Requires iMatix GSL, from http:\\www.nuget.org\packages\gsl
 
+mkdir ..\data
 mkdir ..\src\commands
 mkdir ..\include\bitcoin\explorer\commands
 

--- a/model/generate.gsl
+++ b/model/generate.gsl
@@ -1148,6 +1148,12 @@ doc_DATA = README INSTALL COPYING
 #
 pkgconfig_DATA = libbitcoin-explorer.pc
 
+# bash completion
+if ENABLE_BASH_COMPLETION
+bashcompletiondir = \$(BASH_COMPLETION_DIR)
+dist_bashcompletion_DATA = data/bx
+endif
+
 # look for macros in the m4 subdirectory
 ACLOCAL_AMFLAGS = -I m4
 
@@ -1340,6 +1346,35 @@ test_libbitcoin_explorer_test_LDADD = \\
     ${bitcoin_client_LIBS}
 
 endif
+
+.##############################################################################
+.echo "Generating data/bx..."
+.output "../data/bx"
+#
+#  Command-line completion for bx
+#
+_bx()
+{
+    local current="${COMP_WORDS[COMP_CWORD]}"
+    local commands="
+.for command by symbol
+        $(symbol:)
+.endfor
+    "
+
+    if [ $COMP_CWORD -eq 1 ]; then
+        COMPREPLY=( \$(compgen -W "$commands" -- $current) )
+        return
+    fi
+
+    local command=COMP_WORDS[1]
+    local options="--config --help -c -h"
+
+    # TODO: Generate per-command options here
+
+    COMPREPLY=( \$(compgen -W "$options" -- $current) )
+}
+complete -F _bx bx
 
 .##############################################################################
 .echo "Generating builds/msvc/vs2013/libbitcoin-explorer/libbitcoin-explorer.vcxproj..."


### PR DESCRIPTION
I'm not entirely happy with requiring "bash-completion >= 2.0" to actually be installed. Perhaps this should default to false, or should auto-detect based on the presence of that package? Anyhow, I'm putting this here so it doesn't get lost.
