### PR TITLE
compatibility change was only added for widely used address.fetch_history

### DIFF
--- a/src/commands/fetch-history.cpp
+++ b/src/commands/fetch-history.cpp
@@ -59,7 +59,7 @@ static void fetch_history_from_address(obelisk_client& client,
         handle_error(state, error);
     };
 
-    client.get_codec()->fetch_history(on_error, on_done, address);
+    client.get_codec()->address_fetch_history(on_error, on_done, address);
 }
 
 // When you restore your wallet, you should use fetch_history(). 


### PR DESCRIPTION
compatibility change was only added for widely used address.fetch_history (unconfirmed + confirmed txs), not for the blockchain.fetch_history version (only confirmed txs direct from blockchain db).