### PR TITLE
Fix script-to-address missing stdin=true metadata attribute.

### DIFF
--- a/include/bitcoin/explorer/commands/script-to-address.hpp
+++ b/include/bitcoin/explorer/commands/script-to-address.hpp
@@ -134,6 +134,7 @@ public:
     BCX_API virtual void load_fallbacks(std::istream& input, 
         po::variables_map& variables)
     {
+        load_input(get_tokens_argument(), "TOKEN", variables, input);
     }
 
     /**

--- a/model/generate.xml
+++ b/model/generate.xml
@@ -412,7 +412,7 @@
   </command>
   
   <command symbol="script-to-address" formerly="scripthash" typeX="address" category="TRANSACTION" description="Create a BIP16 pay-to-script-hash address from an encoded script.">
-    <argument name="TOKEN" fileX="true" limit="-1" type="string" description="The script. If not specified the script is read from STDIN."/>
+    <argument name="TOKEN" fileX="true" stdin="true" limit="-1" type="string" description="The script. If not specified the script is read from STDIN."/>
   </command>
   
   <command symbol="seed" typeX="base16" category="WALLET" description="Generate a pseudorandom seed.">

--- a/src/commands/script-to-address.cpp
+++ b/src/commands/script-to-address.cpp
@@ -42,4 +42,3 @@ console_result script_to_address::invoke(std::ostream& output, std::ostream& err
     output << script_hash_address << std::endl;
     return console_result::okay;
 }
-


### PR DESCRIPTION
This resulted in STDIN being ignored for the `script-to-address` command, producing an address associated with an empty script.