### PR TITLE
Correct the data type for wallet.transaction_version

### DIFF
--- a/data/bx.cfg
+++ b/data/bx.cfg
@@ -12,7 +12,7 @@ pay_to_public_key_hash_version = 0
 # The pay-to-script-hash address version, defaults to 5.
 pay_to_script_hash_version = 5
 # The transaction version, defaults to 1.
-transaction_version = 5
+transaction_version = 1
 
 [network]
 # The magic number for message headers, defaults to 3652501241.

--- a/include/bitcoin/explorer/command.hpp
+++ b/include/bitcoin/explorer/command.hpp
@@ -226,7 +226,7 @@ public:
         )
         (
             "wallet.transaction_version",
-            value<primitives::byte>(&setting_.wallet.transaction_version)->default_value(1),
+            value<uint32_t>(&setting_.wallet.transaction_version)->default_value(1),
             "The transaction version, defaults to 1."
         )
         (
@@ -428,7 +428,7 @@ public:
     /**
      * Get the value of the wallet.transaction_version setting.
      */
-    virtual primitives::byte get_wallet_transaction_version_setting() const
+    virtual uint32_t get_wallet_transaction_version_setting() const
     {
         return setting_.wallet.transaction_version;
     }
@@ -436,7 +436,7 @@ public:
     /**
      * Set the value of the wallet.transaction_version setting.
      */
-    virtual void set_wallet_transaction_version_setting(primitives::byte value)
+    virtual void set_wallet_transaction_version_setting(uint32_t value)
     {
         setting_.wallet.transaction_version = value;
     }
@@ -708,7 +708,7 @@ private:
             uint32_t hd_secret_version;
             primitives::byte pay_to_public_key_hash_version;
             primitives::byte pay_to_script_hash_version;
-            primitives::byte transaction_version;
+            uint32_t transaction_version;
         } wallet;
 
         struct network

--- a/model/generate.xml
+++ b/model/generate.xml
@@ -36,7 +36,7 @@
     <setting name="hd_secret_version" type="uint32_t" default="76066276" description="The hierarchical deterministic (HD) private key version, defaults to 76066276." />
     <setting name="pay_to_public_key_hash_version" type="byte" default="0" description="The pay-to-public-key-hash address version, defaults to 0." />
     <setting name="pay_to_script_hash_version" type="byte" default="5" description="The pay-to-script-hash address version, defaults to 5." />
-    <setting name="transaction_version" type="byte" default="1" description="The transaction version, defaults to 1." />
+    <setting name="transaction_version" type="uint32_t" default="1" description="The transaction version, defaults to 1." />
   </configuration>
 
   <configuration section="network">


### PR DESCRIPTION
Correct the data type for wallet.transaction_version for generation to ensure proper runtime functioning of tx-encode (resolves #333).