### PR TITLE
add namespace including in commands/*.cpp

### DIFF
--- a/src/commands/address-decode.cpp
+++ b/src/commands/address-decode.cpp
@@ -25,9 +25,9 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/config/wrapper.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result address_decode::invoke(std::ostream& output,
@@ -42,3 +42,7 @@ console_result address_decode::invoke(std::ostream& output,
 
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/address-embed.cpp
+++ b/src/commands/address-embed.cpp
@@ -26,10 +26,10 @@
 #include <bitcoin/explorer/config/script.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::chain;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::wallet;
 
 console_result address_embed::invoke(std::ostream& output, std::ostream& error)
@@ -49,3 +49,7 @@ console_result address_embed::invoke(std::ostream& output, std::ostream& error)
     output << payment_address(hash, version) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/address-encode.cpp
+++ b/src/commands/address-encode.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result address_encode::invoke(std::ostream& output,
@@ -38,3 +38,7 @@ console_result address_encode::invoke(std::ostream& output,
     output << payment_address(ripemd160, version) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/base16-decode.cpp
+++ b/src/commands/base16-decode.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/raw.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result base16_decode::invoke(std::ostream& output, std::ostream& error)
@@ -38,3 +38,7 @@ console_result base16_decode::invoke(std::ostream& output, std::ostream& error)
     output << raw(base16) /* << std::endl */;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/base16-encode.cpp
+++ b/src/commands/base16-encode.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result base16_encode::invoke(std::ostream& output, std::ostream& error)
 {
@@ -36,3 +36,7 @@ console_result base16_encode::invoke(std::ostream& output, std::ostream& error)
     output << base16(data) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/base58-decode.cpp
+++ b/src/commands/base58-decode.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result base58_decode::invoke(std::ostream& output, std::ostream& error)
 {
@@ -36,3 +36,7 @@ console_result base58_decode::invoke(std::ostream& output, std::ostream& error)
     output << base16(base58) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/base58-encode.cpp
+++ b/src/commands/base58-encode.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result base58_encode::invoke(std::ostream& output, std::ostream& error)
 {
@@ -36,3 +36,7 @@ console_result base58_encode::invoke(std::ostream& output, std::ostream& error)
     output << base58(base16) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/base58check-decode.cpp
+++ b/src/commands/base58check-decode.cpp
@@ -25,9 +25,9 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/config/wrapper.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result base58check_decode::invoke(std::ostream& output,
@@ -43,3 +43,7 @@ console_result base58check_decode::invoke(std::ostream& output,
     write_stream(output, tree, encoding);
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/base58check-encode.cpp
+++ b/src/commands/base58check-encode.cpp
@@ -24,10 +24,10 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/wrapper.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 
 console_result base58check_encode::invoke(std::ostream& output, 
@@ -44,3 +44,7 @@ console_result base58check_encode::invoke(std::ostream& output,
     output << base58check << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/base64-decode.cpp
+++ b/src/commands/base64-decode.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/raw.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result base64_decode::invoke(std::ostream& output, std::ostream& error)
@@ -39,3 +39,7 @@ console_result base64_decode::invoke(std::ostream& output, std::ostream& error)
 
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/base64-encode.cpp
+++ b/src/commands/base64-encode.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result base64_encode::invoke(std::ostream& output, std::ostream& error)
 {
@@ -36,3 +36,7 @@ console_result base64_encode::invoke(std::ostream& output, std::ostream& error)
     output << base64(data) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/bitcoin160.cpp
+++ b/src/commands/bitcoin160.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result bitcoin160::invoke(std::ostream& output, std::ostream& error)
 {
@@ -38,3 +38,7 @@ console_result bitcoin160::invoke(std::ostream& output, std::ostream& error)
     output << base16(hash) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/bitcoin256.cpp
+++ b/src/commands/bitcoin256.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 
 console_result bitcoin256::invoke(std::ostream& output, std::ostream& error)
@@ -39,3 +39,7 @@ console_result bitcoin256::invoke(std::ostream& output, std::ostream& error)
     output << hash256(hash) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/btc-to-satoshi.cpp
+++ b/src/commands/btc-to-satoshi.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result btc_to_satoshi::invoke(std::ostream& output, 
@@ -40,3 +40,7 @@ console_result btc_to_satoshi::invoke(std::ostream& output,
     output << satoshi << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/cert-new.cpp
+++ b/src/commands/cert-new.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::protocol;
 
 console_result cert_new::invoke(std::ostream& output, std::ostream& error)
@@ -46,3 +46,7 @@ console_result cert_new::invoke(std::ostream& output, std::ostream& error)
     output << certificate.private_key() << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/cert-public.cpp
+++ b/src/commands/cert-public.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::protocol;
 
 console_result cert_public::invoke(std::ostream& output, std::ostream& error)
@@ -48,3 +48,7 @@ console_result cert_public::invoke(std::ostream& output, std::ostream& error)
     output << certificate.public_key() << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ec-add-secrets.cpp
+++ b/src/commands/ec-add-secrets.cpp
@@ -24,9 +24,10 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/ec_private.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result ec_add_secrets::invoke(std::ostream& output, std::ostream& error)
 {
@@ -56,3 +57,7 @@ console_result ec_add_secrets::invoke(std::ostream& output, std::ostream& error)
     return console_result::okay;
 }
 
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ec-add.cpp
+++ b/src/commands/ec-add.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ec_add::invoke(std::ostream& output, std::ostream& error)
@@ -48,3 +48,7 @@ console_result ec_add::invoke(std::ostream& output, std::ostream& error)
     output << ec_public(sum, point.compressed()) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ec-multiply-secrets.cpp
+++ b/src/commands/ec-multiply-secrets.cpp
@@ -24,9 +24,10 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/ec_private.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result ec_multiply_secrets::invoke(std::ostream& output, std::ostream& error)
 {
@@ -56,3 +57,7 @@ console_result ec_multiply_secrets::invoke(std::ostream& output, std::ostream& e
     return console_result::okay;
 }
 
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ec-multiply.cpp
+++ b/src/commands/ec-multiply.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ec_multiply::invoke(std::ostream& output, std::ostream& error)
@@ -48,3 +48,7 @@ console_result ec_multiply::invoke(std::ostream& output, std::ostream& error)
     output << ec_public(product, point.compressed()) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ec-new.cpp
+++ b/src/commands/ec-new.cpp
@@ -25,12 +25,13 @@
 #include <bitcoin/explorer/utility.hpp>
 #include <bitcoin/explorer/config/ec_private.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 // The BX_EC_NEW_INVALID_KEY condition is not covered by test.
 // This is because is not known what seed will produce an invalid key.
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
+
 console_result ec_new::invoke(std::ostream& output, std::ostream& error)
 {
     // Bound parameters.
@@ -53,3 +54,7 @@ console_result ec_new::invoke(std::ostream& output, std::ostream& error)
     output << config::ec_private(secret) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ec-to-address.cpp
+++ b/src/commands/ec-to-address.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ec_to_address::invoke(std::ostream& output, std::ostream& error)
@@ -37,3 +37,7 @@ console_result ec_to_address::invoke(std::ostream& output, std::ostream& error)
     output << payment_address(point, version) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ec-to-ek.cpp
+++ b/src/commands/ec-to-ek.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ec_to_ek::invoke(std::ostream& output, std::ostream& error)
@@ -46,3 +46,7 @@ console_result ec_to_ek::invoke(std::ostream& output, std::ostream& error)
     return console_result::failure;
 #endif
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ec-to-public.cpp
+++ b/src/commands/ec-to-public.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 // In the case of failure this produces ec_compressed_null.
@@ -41,3 +41,7 @@ console_result ec_to_public::invoke(std::ostream& output, std::ostream& error)
     output << ec_public(point, !uncompressed) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ec-to-wif.cpp
+++ b/src/commands/ec-to-wif.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ec_to_wif::invoke(std::ostream& output, std::ostream& error)
@@ -44,3 +44,7 @@ console_result ec_to_wif::invoke(std::ostream& output, std::ostream& error)
     output << ec_private(secret, version, !uncompressed) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ek-address.cpp
+++ b/src/commands/ek-address.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ek_address::invoke(std::ostream& output, std::ostream& error)
@@ -54,3 +54,7 @@ console_result ek_address::invoke(std::ostream& output, std::ostream& error)
     output << address << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ek-new.cpp
+++ b/src/commands/ek-new.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ek_new::invoke(std::ostream& output, std::ostream& error)
@@ -52,3 +52,7 @@ console_result ek_new::invoke(std::ostream& output, std::ostream& error)
     output << ek_private(secret) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ek-public-to-address.cpp
+++ b/src/commands/ek-public-to-address.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ek_public_to_address::invoke(std::ostream& output,
@@ -55,3 +55,7 @@ console_result ek_public_to_address::invoke(std::ostream& output,
 #endif
 }
 
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ek-public-to-ec.cpp
+++ b/src/commands/ek-public-to-ec.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ek_public_to_ec::invoke(std::ostream& output,
@@ -52,3 +52,7 @@ console_result ek_public_to_ec::invoke(std::ostream& output,
     return console_result::failure;
 #endif
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ek-public.cpp
+++ b/src/commands/ek-public.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result commands::ek_public::invoke(std::ostream& output,
@@ -55,3 +55,7 @@ console_result commands::ek_public::invoke(std::ostream& output,
     output << bc::wallet::ek_public(key) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ek-to-address.cpp
+++ b/src/commands/ek-to-address.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ek_to_address::invoke(std::ostream& output, std::ostream& error)
@@ -55,3 +55,7 @@ console_result ek_to_address::invoke(std::ostream& output, std::ostream& error)
     return console_result::failure;
 #endif
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ek-to-ec.cpp
+++ b/src/commands/ek-to-ec.cpp
@@ -26,9 +26,9 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/ec_private.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result ek_to_ec::invoke(std::ostream& output, std::ostream& error)
@@ -53,3 +53,7 @@ console_result ek_to_ec::invoke(std::ostream& output, std::ostream& error)
     return console_result::failure;
 #endif
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/fetch-balance.cpp
+++ b/src/commands/fetch-balance.cpp
@@ -28,11 +28,11 @@
 #include <bitcoin/explorer/display.hpp>
 #include <bitcoin/explorer/prop_tree.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::chain;
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 
 console_result fetch_balance::invoke(std::ostream& output, std::ostream& error)
@@ -70,3 +70,7 @@ console_result fetch_balance::invoke(std::ostream& output, std::ostream& error)
 
     return state.get_result();
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/fetch-header.cpp
+++ b/src/commands/fetch-header.cpp
@@ -30,10 +30,10 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 
 console_result fetch_header::invoke(std::ostream& output, std::ostream& error)
@@ -76,3 +76,7 @@ console_result fetch_header::invoke(std::ostream& output, std::ostream& error)
     return state.get_result();
 }
 
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/fetch-height.cpp
+++ b/src/commands/fetch-height.cpp
@@ -28,10 +28,10 @@
 #include <bitcoin/explorer/display.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 
 console_result fetch_height::invoke(std::ostream& output, std::ostream& error)
@@ -77,3 +77,7 @@ console_result fetch_height::invoke(std::ostream& output, std::ostream& error)
 
     return state.get_result();
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/fetch-history.cpp
+++ b/src/commands/fetch-history.cpp
@@ -27,11 +27,11 @@
 #include <bitcoin/explorer/display.hpp>
 #include <bitcoin/explorer/prop_tree.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::chain;
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 
 // When you restore your wallet, you should use fetch_history(). 
@@ -79,3 +79,7 @@ console_result fetch_history::invoke(std::ostream& output, std::ostream& error)
 
     return state.get_result();
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/fetch-public-key.cpp
+++ b/src/commands/fetch-public-key.cpp
@@ -26,10 +26,10 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/display.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result fetch_public_key::invoke(std::ostream& output, std::ostream& error)
 {
@@ -70,3 +70,7 @@ console_result fetch_public_key::invoke(std::ostream& output, std::ostream& erro
     error << BX_FETCH_PUBLIC_KEY_NOT_IMPLEMENTED << std::endl;
     return console_result::failure;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/fetch-stealth.cpp
+++ b/src/commands/fetch-stealth.cpp
@@ -27,11 +27,11 @@
 #include <bitcoin/explorer/display.hpp>
 #include <bitcoin/explorer/prop_tree.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::chain;
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 using namespace bc::wallet;
 
@@ -78,3 +78,7 @@ console_result fetch_stealth::invoke(std::ostream& output, std::ostream& error)
 
     return state.get_result();
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/fetch-tx-index.cpp
+++ b/src/commands/fetch-tx-index.cpp
@@ -29,10 +29,10 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 
 // This call is deprecated at the server.
@@ -69,3 +69,7 @@ console_result fetch_tx_index::invoke(std::ostream& output, std::ostream& error)
     return state.get_result();
 }
 
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/fetch-tx.cpp
+++ b/src/commands/fetch-tx.cpp
@@ -29,10 +29,10 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 
 console_result fetch_tx::invoke(std::ostream& output, std::ostream& error)
@@ -71,3 +71,7 @@ console_result fetch_tx::invoke(std::ostream& output, std::ostream& error)
     return state.get_result();
 }
 
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/fetch-utxo.cpp
+++ b/src/commands/fetch-utxo.cpp
@@ -28,10 +28,10 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/config/algorithm.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 
 console_result fetch_utxo::invoke(std::ostream& output, std::ostream& error)
@@ -72,3 +72,7 @@ console_result fetch_utxo::invoke(std::ostream& output, std::ostream& error)
 
     return state.get_result();
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/hd-new.cpp
+++ b/src/commands/hd-new.cpp
@@ -23,12 +23,13 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 // The BX_HD_NEW_INVALID_KEY condition is uncovered by test.
 // This is because is not known what seed will produce an invalid key.
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
+
 console_result hd_new::invoke(std::ostream& output, std::ostream& error)
 {
     // Bound parameters.
@@ -54,3 +55,7 @@ console_result hd_new::invoke(std::ostream& output, std::ostream& error)
     output << private_key << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/hd-private.cpp
+++ b/src/commands/hd-private.cpp
@@ -23,9 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result hd_private::invoke(std::ostream& output, std::ostream& error)
 {
@@ -47,3 +48,7 @@ console_result hd_private::invoke(std::ostream& output, std::ostream& error)
     output << child_private_key << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/hd-public.cpp
+++ b/src/commands/hd-public.cpp
@@ -23,9 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result hd_public::invoke(std::ostream& output, std::ostream& error)
 {
@@ -88,3 +89,7 @@ console_result hd_public::invoke(std::ostream& output, std::ostream& error)
     output << "ERROR_KEY" << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/hd-to-address.cpp
+++ b/src/commands/hd-to-address.cpp
@@ -23,12 +23,17 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result hd_to_address::invoke(std::ostream& output, std::ostream& error)
 {
     error << BX_HD_TO_ADDRESS_OBSOLETE << std::endl;
     return console_result::failure;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/hd-to-ec.cpp
+++ b/src/commands/hd-to-ec.cpp
@@ -24,9 +24,10 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/ec_private.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result hd_to_ec::invoke(std::ostream& output, std::ostream& error)
 {
@@ -69,3 +70,7 @@ console_result hd_to_ec::invoke(std::ostream& output, std::ostream& error)
     output << "ERROR_VKEY" << std::endl;
     return console_result::failure;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/hd-to-public.cpp
+++ b/src/commands/hd-to-public.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result hd_to_public::invoke(std::ostream& output, std::ostream& error)
@@ -52,3 +52,7 @@ console_result hd_to_public::invoke(std::ostream& output, std::ostream& error)
     output << versioned.to_public() << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/hd-to-wif.cpp
+++ b/src/commands/hd-to-wif.cpp
@@ -22,9 +22,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result hd_to_wif::invoke(std::ostream& output, std::ostream& error)
@@ -32,3 +32,7 @@ console_result hd_to_wif::invoke(std::ostream& output, std::ostream& error)
     error << BX_HD_TO_WIF_OBSOLETE << std::endl;
     return console_result::failure;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/help.cpp
+++ b/src/commands/help.cpp
@@ -26,9 +26,10 @@
 #include <bitcoin/explorer/display.hpp>
 #include <bitcoin/explorer/generated.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result help::invoke(std::ostream& output, std::ostream& error)
 {
@@ -53,3 +54,7 @@ console_result help::invoke(std::ostream& output, std::ostream& error)
     command->write_help(output);
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/input-set.cpp
+++ b/src/commands/input-set.cpp
@@ -25,9 +25,9 @@
 #include <bitcoin/explorer/config/transaction.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result input_set::invoke(std::ostream& output, std::ostream& error)
@@ -52,3 +52,7 @@ console_result input_set::invoke(std::ostream& output, std::ostream& error)
     output << tx_copy << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/input-sign.cpp
+++ b/src/commands/input-sign.cpp
@@ -24,11 +24,11 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::chain;
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 // The BX_INPUT_SIGN_FAILED condition uncovered by test.
 // This is because a vector to produce the failure is not known.
@@ -63,3 +63,7 @@ console_result input_sign::invoke(std::ostream& output, std::ostream& error)
     output << base16(endorse) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/input-validate.cpp
+++ b/src/commands/input-validate.cpp
@@ -23,10 +23,10 @@
 #include <cstdint>
 #include <bitcoin/bitcoin.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::chain;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result input_validate::invoke(std::ostream& output,
     std::ostream& error)
@@ -62,3 +62,7 @@ console_result input_validate::invoke(std::ostream& output,
     output << BX_INPUT_VALIDATE_INDEX_VALID_ENDORSEMENT << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/message-sign.cpp
+++ b/src/commands/message-sign.cpp
@@ -25,9 +25,9 @@
 #include <bitcoin/explorer/config/signature.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 using namespace bc::wallet;
 
@@ -44,3 +44,7 @@ console_result message_sign::invoke(std::ostream& output, std::ostream& error)
     output << signature(sign) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/message-validate.cpp
+++ b/src/commands/message-validate.cpp
@@ -22,9 +22,9 @@
 #include <iostream>
 #include <bitcoin/bitcoin.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result message_validate::invoke(std::ostream& output,
@@ -45,3 +45,7 @@ console_result message_validate::invoke(std::ostream& output,
     output << BX_MESSAGE_VALIDATE_INDEX_VALID_SIGNATURE << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/mnemonic-decode.cpp
+++ b/src/commands/mnemonic-decode.cpp
@@ -24,9 +24,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result mnemonic_decode::invoke(std::ostream& output,
     std::ostream& error)
@@ -34,3 +35,7 @@ console_result mnemonic_decode::invoke(std::ostream& output,
     error << BX_MNEMONIC_DECODE_OBSOLETE << std::endl;
     return console_result::failure;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/mnemonic-encode.cpp
+++ b/src/commands/mnemonic-encode.cpp
@@ -24,9 +24,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result mnemonic_encode::invoke(std::ostream& output,
     std::ostream& error)
@@ -34,3 +35,7 @@ console_result mnemonic_encode::invoke(std::ostream& output,
     error << BX_MNEMONIC_ENCODE_OBSOLETE << std::endl;
     return console_result::failure;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/mnemonic-new.cpp
+++ b/src/commands/mnemonic-new.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result mnemonic_new::invoke(std::ostream& output,
     std::ostream& error)
@@ -50,3 +50,7 @@ console_result mnemonic_new::invoke(std::ostream& output,
     output << join(words) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/mnemonic-to-seed.cpp
+++ b/src/commands/mnemonic-to-seed.cpp
@@ -23,11 +23,11 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
 using namespace bc::wallet;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result mnemonic_to_seed::invoke(std::ostream& output,
     std::ostream& error)
@@ -74,3 +74,7 @@ console_result mnemonic_to_seed::invoke(std::ostream& output,
     output << base16(seed) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/qrcode.cpp
+++ b/src/commands/qrcode.cpp
@@ -25,10 +25,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result qrcode::invoke(std::ostream& output, std::ostream& error)
 {
@@ -75,3 +75,7 @@ console_result qrcode::invoke(std::ostream& output, std::ostream& error)
     return console_result::failure;
 #endif // WITH_QRENCODE
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/ripemd160.cpp
+++ b/src/commands/ripemd160.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result ripemd160::invoke(std::ostream& output, std::ostream& error)
 {
@@ -38,3 +38,7 @@ console_result ripemd160::invoke(std::ostream& output, std::ostream& error)
     output << base16(hash) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/satoshi-to-btc.cpp
+++ b/src/commands/satoshi-to-btc.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/btc.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result satoshi_to_btc::invoke(std::ostream& output,
@@ -38,3 +38,7 @@ console_result satoshi_to_btc::invoke(std::ostream& output,
     output << btc(satoshi) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/script-decode.cpp
+++ b/src/commands/script-decode.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/script.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result script_decode::invoke(std::ostream& output, std::ostream& error)
@@ -38,3 +38,7 @@ console_result script_decode::invoke(std::ostream& output, std::ostream& error)
     output << script(base16) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/script-encode.cpp
+++ b/src/commands/script-encode.cpp
@@ -24,10 +24,10 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/script.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result script_encode::invoke(std::ostream& output, std::ostream& error)
 {
@@ -39,3 +39,7 @@ console_result script_encode::invoke(std::ostream& output, std::ostream& error)
     output << base16(encoded_script) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/script-to-address.cpp
+++ b/src/commands/script-to-address.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result script_to_address::invoke(std::ostream& output, std::ostream& error)
@@ -39,3 +39,7 @@ console_result script_to_address::invoke(std::ostream& output, std::ostream& err
     output << address << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/seed.cpp
+++ b/src/commands/seed.cpp
@@ -24,10 +24,10 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result seed::invoke(std::ostream& output, std::ostream& error)
 {
@@ -47,3 +47,7 @@ console_result seed::invoke(std::ostream& output, std::ostream& error)
     output << base16(seed) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/send-tx-node.cpp
+++ b/src/commands/send-tx-node.cpp
@@ -32,9 +32,9 @@
 #include <bitcoin/explorer/config/transaction.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 using namespace bc::network;
 
@@ -124,3 +124,7 @@ console_result send_tx_node::invoke(std::ostream& output, std::ostream& error)
 
     return state.get_result();
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/send-tx-p2p.cpp
+++ b/src/commands/send-tx-p2p.cpp
@@ -33,9 +33,9 @@
 #include <bitcoin/explorer/config/transaction.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 using namespace bc::network;
 
@@ -155,3 +155,7 @@ console_result send_tx_p2p::invoke(std::ostream& output, std::ostream& error)
 
     return state.get_result();
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/send-tx.cpp
+++ b/src/commands/send-tx.cpp
@@ -28,10 +28,10 @@
 #include <bitcoin/explorer/display.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result send_tx::invoke(std::ostream& output, std::ostream& error)
 {
@@ -64,3 +64,7 @@ console_result send_tx::invoke(std::ostream& output, std::ostream& error)
 
     return state.get_result();
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/settings.cpp
+++ b/src/commands/settings.cpp
@@ -25,9 +25,9 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 using namespace pt;
 
@@ -100,3 +100,7 @@ console_result commands::settings::invoke(std::ostream& output,
     write_stream(output, prop_tree(list), encoding);
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/sha160.cpp
+++ b/src/commands/sha160.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result sha160::invoke(std::ostream& output, std::ostream& error)
 {
@@ -38,3 +38,7 @@ console_result sha160::invoke(std::ostream& output, std::ostream& error)
     output << base16(hash) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/sha256.cpp
+++ b/src/commands/sha256.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result sha256::invoke(std::ostream& output, std::ostream& error)
 {
@@ -38,3 +38,7 @@ console_result sha256::invoke(std::ostream& output, std::ostream& error)
     output << base16(hash) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/sha512.cpp
+++ b/src/commands/sha512.cpp
@@ -23,10 +23,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::config;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 console_result sha512::invoke(std::ostream& output, std::ostream& error)
 {
@@ -38,3 +38,7 @@ console_result sha512::invoke(std::ostream& output, std::ostream& error)
     output << base16(hash) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/stealth-decode.cpp
+++ b/src/commands/stealth-decode.cpp
@@ -25,9 +25,9 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result stealth_decode::invoke(std::ostream& output,
@@ -43,3 +43,7 @@ console_result stealth_decode::invoke(std::ostream& output,
     write_stream(output, prop_tree(address, json), encoding);
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/stealth-encode.cpp
+++ b/src/commands/stealth-encode.cpp
@@ -25,9 +25,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result stealth_encode::invoke(std::ostream& output,
@@ -66,3 +66,7 @@ console_result stealth_encode::invoke(std::ostream& output,
     output << address << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/stealth-public.cpp
+++ b/src/commands/stealth-public.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 // This is nearly the same as ec-add.
@@ -46,3 +46,7 @@ console_result stealth_public::invoke(std::ostream& output,
     output << ec_public(sum) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/stealth-secret.cpp
+++ b/src/commands/stealth-secret.cpp
@@ -24,11 +24,12 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/ec_private.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 // This is nearly the same as ec-add-secrets.
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
+
 console_result stealth_secret::invoke(std::ostream& output,
     std::ostream& error)
 {
@@ -46,3 +47,7 @@ console_result stealth_secret::invoke(std::ostream& output,
     output << config::ec_private(sum) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/stealth-shared.cpp
+++ b/src/commands/stealth-shared.cpp
@@ -23,12 +23,13 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 
 // This is nearly the same as ec-multiply + sha256.
 // Pass either (ephem_secret, scan_pubkey) or (scan_secret, ephem_pubkey).
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
+
 console_result stealth_shared::invoke(std::ostream& output,
     std::ostream& error)
 {
@@ -48,3 +49,7 @@ console_result stealth_shared::invoke(std::ostream& output,
     output << config::ec_private(hash) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/token-new.cpp
+++ b/src/commands/token-new.cpp
@@ -23,9 +23,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 using namespace bc::wallet;
 
@@ -76,3 +76,7 @@ console_result token_new::invoke(std::ostream& output, std::ostream& error)
     return console_result::failure;
 #endif
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/tx-decode.cpp
+++ b/src/commands/tx-decode.cpp
@@ -25,9 +25,9 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result tx_decode::invoke(std::ostream& output, std::ostream& error)
@@ -43,3 +43,7 @@ console_result tx_decode::invoke(std::ostream& output, std::ostream& error)
 
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/tx-encode.cpp
+++ b/src/commands/tx-encode.cpp
@@ -25,9 +25,9 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/transaction.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 using namespace bc::wallet;
 
@@ -107,3 +107,7 @@ console_result tx_encode::invoke(std::ostream& output, std::ostream& error)
     output << transaction(tx) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/tx-sign.cpp
+++ b/src/commands/tx-sign.cpp
@@ -25,9 +25,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result tx_sign::invoke(std::ostream& output, std::ostream& error)
 {
@@ -40,3 +41,7 @@ console_result tx_sign::invoke(std::ostream& output, std::ostream& error)
     error << BX_TX_SIGN_NOT_IMPLEMENTED << std::endl;
     return console_result::failure;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/uri-decode.cpp
+++ b/src/commands/uri-decode.cpp
@@ -25,9 +25,9 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
  console_result uri_decode::invoke(std::ostream& output, std::ostream& error)
@@ -39,3 +39,7 @@ using namespace bc::explorer::config;
      write_stream(output, prop_tree(uri), encoding);
      return console_result::okay;
  }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/uri-encode.cpp
+++ b/src/commands/uri-encode.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
  console_result uri_encode::invoke(std::ostream& output, std::ostream& error)
@@ -58,3 +58,7 @@ using namespace bc::wallet;
      output << uri.encoded() << std::endl;
      return console_result::okay;
  }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/validate-tx.cpp
+++ b/src/commands/validate-tx.cpp
@@ -28,10 +28,10 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 
 console_result validate_tx::invoke(std::ostream& output,
@@ -76,3 +76,7 @@ console_result validate_tx::invoke(std::ostream& output,
 
     return state.get_result();
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/watch-address.cpp
+++ b/src/commands/watch-address.cpp
@@ -32,10 +32,10 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::client;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
 using namespace bc::explorer::config;
 using namespace bc::wallet;
 
@@ -109,3 +109,7 @@ console_result watch_address::invoke(std::ostream& output, std::ostream& error)
 
     return state.get_result();
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/watch-tx.cpp
+++ b/src/commands/watch-tx.cpp
@@ -24,9 +24,10 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result watch_tx::invoke(std::ostream& output, std::ostream& error)
 {
@@ -37,3 +38,7 @@ console_result watch_tx::invoke(std::ostream& output, std::ostream& error)
     error << BX_WATCH_TX_NOT_IMPLEMENTED << std::endl;
     return console_result::failure;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/wif-to-ec.cpp
+++ b/src/commands/wif-to-ec.cpp
@@ -24,9 +24,10 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/ec_private.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result wif_to_ec::invoke(std::ostream& output, std::ostream& error)
 {
@@ -36,3 +37,7 @@ console_result wif_to_ec::invoke(std::ostream& output, std::ostream& error)
     output << config::ec_private(secret) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/wif-to-public.cpp
+++ b/src/commands/wif-to-public.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/explorer/define.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::wallet;
 
 console_result wif_to_public::invoke(std::ostream& output, std::ostream& error)
@@ -37,3 +37,7 @@ console_result wif_to_public::invoke(std::ostream& output, std::ostream& error)
     output << ec_public(secret) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/wrap-decode.cpp
+++ b/src/commands/wrap-decode.cpp
@@ -25,9 +25,10 @@
 #include <bitcoin/explorer/prop_tree.hpp>
 #include <bitcoin/explorer/utility.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 
 console_result wrap_decode::invoke(std::ostream& output, std::ostream& error)
 {
@@ -40,3 +41,7 @@ console_result wrap_decode::invoke(std::ostream& output, std::ostream& error)
     write_stream(output, tree, encoding);
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 

--- a/src/commands/wrap-encode.cpp
+++ b/src/commands/wrap-encode.cpp
@@ -24,9 +24,9 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/config/wrapper.hpp>
 
-using namespace bc;
-using namespace bc::explorer;
-using namespace bc::explorer::commands;
+namespace libbitcoin {
+namespace explorer {
+namespace commands {
 using namespace bc::explorer::config;
 
 console_result wrap_encode::invoke(std::ostream& output, std::ostream& error)
@@ -38,3 +38,7 @@ console_result wrap_encode::invoke(std::ostream& output, std::ostream& error)
     output << wrapper(version, payload) << std::endl;
     return console_result::okay;
 }
+
+} //namespace commands 
+} //namespace explorer 
+} //namespace libbitcoin 


### PR DESCRIPTION
by Linux 'sed' command.

However, files 'uri-decode.cpp' and 'uri-encode.cpp', removed redundancy white-spaces at the front of each line manually.

