### PR TITLE
Set minimum_seed_bits to 192 (instead 128)

### DIFF
--- a/include/bitcoin/explorer/define.hpp
+++ b/include/bitcoin/explorer/define.hpp
@@ -90,7 +90,7 @@ typedef bc::chain::output tx_output_type;
 /**
  * The minimum safe length of a seed in bits (multiple of 8).
  */
-BC_CONSTEXPR size_t minimum_seed_bits = 128;
+BC_CONSTEXPR size_t minimum_seed_bits = 192;
 
 /**
  * The minimum safe length of a seed in bytes (16).


### PR DESCRIPTION
According to the wiki page [random numbers][1] the minimum and default seed bits is `192`. However, using `128` unexpectedly works for me:
```bash
hsk81 libbitcoin-explorer.git@master $ bx seed --bit_length 128
3d99b73f054e57c78fe2efd698a5a9c5
```

This is either a documentation issue in the wiki [page][1] or the seed bits should indeed have a minimum of `192`.

[1]: https://github.com/libbitcoin/libbitcoin-explorer/wiki/Random-Numbers