### PR TITLE
Replaced depreciated random_fill w/pseudo_random_fill

### DIFF
--- a/include/bitcoin/explorer/utility.hpp
+++ b/include/bitcoin/explorer/utility.hpp
@@ -200,13 +200,6 @@ BCX_API data_chunk new_seed(size_t bit_length=minimum_seed_bits);
 BCX_API string_list numbers_to_strings(const chain::point::indexes& indexes);
 
 /**
- * DEPRECATED in favor of libbitcoin::pseudo_random_fill.
- * Fill a buffer with randomness using the default random engine.
- * @param[in]  chunk  The buffer to fill with randomness.
- */
-BCX_API void random_fill(data_chunk& chunk);
-
-/**
  * Get a message from the specified input stream.
  * @param[in]  stream The input stream to read.
  * @return            The message read from the input stream.

--- a/model/generate.xml
+++ b/model/generate.xml
@@ -267,12 +267,13 @@
     <option name="height" shortcut="t" type="uint32_t" description="The block height."/>
   </command>
 
-  <!-- TODO: document new public-key argument for 3.x -->
+  <!-- TODO: document new public-key argument for 3.1 -->
   <command symbol="fetch-height" formerly="fetch-last-height" output="uint32_t" category="ONLINE" network="true" description="Get the last block height. Requires a Libbitcoin server connection.">
     <argument name="server-url" description="The URL of the Libbitcoin server to use. If not specified the URL is obtained from configuration settings or defaults."/>
     <argument name="public-key" description="The public key of the Libbitcoin server. If not specified the key is obtained from configuration settings or defaults."/>
   </command>
   
+  <!-- TODO: document simplified output format (no unconfirmed history) for 3.1 -->
   <command symbol="fetch-history" output="history_row" category="ONLINE" network="true" description="Get list of output points, values, and spends for a payment address. Requires a Libbitcoin server connection.">
     <option name="format" type="encoding" description="The output format. Options are 'info', 'json' and 'xml', defaults to 'info'." />
     <argument name="PAYMENT_ADDRESS" stdin="true" type="payment_address" description="The payment address. If not specified the address is read from STDIN." />
@@ -283,7 +284,7 @@
     <define name="BX_FETCH_PUBLIC_KEY_NOT_IMPLEMENTED" value="This command is not yet implemented." />
   </command>
 
-  <!-- TODO: document new limit (8 bit filter) for 3.x release. -->
+  <!-- TODO: document new limit (8 bit filter) for 3.1 -->
   <command symbol="fetch-stealth" output="stealth_row" category="ONLINE" network="true" description="Get metadata on potential payment transactions by stealth prefix filter. Requires a Libbitcoin server connection.">
     <option name="format" type="encoding" description="The output format. Options are 'info', 'json' and 'xml', defaults to 'info'." />
     <option name="height" shortcut="t" type="uint32_t" description="The minimum block height of transactions to include."/>

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -76,7 +76,7 @@ data_chunk new_seed(size_t bit_length)
 {
     size_t fill_seed_size = bit_length / byte_bits;
     data_chunk seed(fill_seed_size);
-    random_fill(seed);
+    pseudo_random_fill(seed);
     return seed;
 }
 
@@ -88,13 +88,6 @@ string_list numbers_to_strings(const chain::point::indexes& indexes)
         stringlist.push_back(std::to_string(index));
 
     return stringlist;
-}
-
-// Not testable due to lack of random engine injection.
-// DEPRECATED in favor of libbitcoin::pseudo_random_fill.
-void random_fill(data_chunk& chunk)
-{
-    pseudo_random_fill(chunk);
 }
 
 // TODO: switch to binary for raw (primitive) reads in windows.


### PR DESCRIPTION
The `utility.cpp::random_fill` has apparently been depreciated; removed it, and used `pseudo_random_fill` instead.