### PR TITLE
Clarifications to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ $ sudo make install # optional
 $ sudo ldconfig     # optional
 ```
 
+In general, you should use the install.sh scripts for Linux or MacOS rather than building from source.
+
 Detailed instructions are provided below.
 * [Debian/Ubuntu](#debianubuntu)
 * [Macintosh](#macintosh)


### PR DESCRIPTION
As a first-time user, I foolishly followed the build instructions rather than using the provided install.sh scripts. This update will hopefully clarify that the build commands are provided primarily for informational purposes and that most users should probably use the scripts instead.