### PR TITLE
propagate new bc::settings class

### DIFF
--- a/include/bitcoin/explorer/command.hpp
+++ b/include/bitcoin/explorer/command.hpp
@@ -298,6 +298,56 @@ public:
             "server.client_private_key",
             value<bc::config::sodium>(&setting_.server.client_private_key),
             "The Z85-encoded private key of the client."
+        )
+        (
+            "bitcoin.retargeting_factor",
+            value<uint32_t>(&setting_.bitcoin.retargeting_factor)->default_value(4),
+            "The URL of the Libbitcoin server."
+        )
+        (
+            "bitcoin.target_spacing_seconds",
+            value<uint32_t>(&setting_.bitcoin.target_spacing_seconds)->default_value(600),
+            "The URL of the Libbitcoin server."
+        )
+        (
+            "bitcoin.easy_spacing_seconds",
+            value<uint32_t>(&setting_.bitcoin.easy_spacing_seconds)->default_value(1200),
+            "The URL of the Libbitcoin server."
+        )
+        (
+            "bitcoin.timestamp_future_seconds",
+            value<uint32_t>(&setting_.bitcoin.timestamp_future_seconds)->default_value(7200),
+            "The URL of the Libbitcoin server."
+        )
+        (
+            "bitcoin.target_timespan_seconds",
+            value<uint32_t>(&setting_.bitcoin.target_timespan_seconds)->default_value(1209600),
+            "The URL of the Libbitcoin server."
+        )
+        (
+            "bitcoin.retarget_proof_of_work_limit",
+            value<uint32_t>(&setting_.bitcoin.retarget_proof_of_work_limit)->default_value(486604799),
+            "The URL of the Libbitcoin server."
+        )
+        (
+            "bitcoin.no_retarget_proof_of_work_limit",
+            value<uint32_t>(&setting_.bitcoin.no_retarget_proof_of_work_limit)->default_value(545259519),
+            "The URL of the Libbitcoin server."
+        )
+        (
+            "bitcoin.min_timespan",
+            value<uint32_t>(&setting_.bitcoin.min_timespan)->default_value(302400),
+            "The URL of the Libbitcoin server."
+        )
+        (
+            "bitcoin.max_timespan",
+            value<uint32_t>(&setting_.bitcoin.max_timespan)->default_value(4838400),
+            "The URL of the Libbitcoin server."
+        )
+        (
+            "bitcoin.retargeting_interval",
+            value<size_t>(&setting_.bitcoin.retargeting_interval)->default_value(2016),
+            "The URL of the Libbitcoin server."
         );
     }
 
@@ -702,6 +752,166 @@ public:
         setting_.server.client_private_key = value;
     }
 
+    /**
+     * Get the value of the bitcoin.retargeting_factor setting.
+     */
+    virtual uint32_t get_bitcoin_retargeting_factor_setting() const
+    {
+        return setting_.bitcoin.retargeting_factor;
+    }
+
+    /**
+     * Set the value of the bitcoin.retargeting_factor setting.
+     */
+    virtual void set_bitcoin_retargeting_factor_setting(uint32_t value)
+    {
+        setting_.bitcoin.retargeting_factor = value;
+    }
+
+    /**
+     * Get the value of the bitcoin.target_spacing_seconds setting.
+     */
+    virtual uint32_t get_bitcoin_target_spacing_seconds_setting() const
+    {
+        return setting_.bitcoin.target_spacing_seconds;
+    }
+
+    /**
+     * Set the value of the bitcoin.target_spacing_seconds setting.
+     */
+    virtual void set_bitcoin_target_spacing_seconds_setting(uint32_t value)
+    {
+        setting_.bitcoin.target_spacing_seconds = value;
+    }
+
+    /**
+     * Get the value of the bitcoin.easy_spacing_seconds setting.
+     */
+    virtual uint32_t get_bitcoin_easy_spacing_seconds_setting() const
+    {
+        return setting_.bitcoin.easy_spacing_seconds;
+    }
+
+    /**
+     * Set the value of the bitcoin.easy_spacing_seconds setting.
+     */
+    virtual void set_bitcoin_easy_spacing_seconds_setting(uint32_t value)
+    {
+        setting_.bitcoin.easy_spacing_seconds = value;
+    }
+
+    /**
+     * Get the value of the bitcoin.timestamp_future_seconds setting.
+     */
+    virtual uint32_t get_bitcoin_timestamp_future_seconds_setting() const
+    {
+        return setting_.bitcoin.timestamp_future_seconds;
+    }
+
+    /**
+     * Set the value of the bitcoin.timestamp_future_seconds setting.
+     */
+    virtual void set_bitcoin_timestamp_future_seconds_setting(uint32_t value)
+    {
+        setting_.bitcoin.timestamp_future_seconds = value;
+    }
+
+    /**
+     * Get the value of the bitcoin.target_timespan_seconds setting.
+     */
+    virtual uint32_t get_bitcoin_target_timespan_seconds_setting() const
+    {
+        return setting_.bitcoin.target_timespan_seconds;
+    }
+
+    /**
+     * Set the value of the bitcoin.target_timespan_seconds setting.
+     */
+    virtual void set_bitcoin_target_timespan_seconds_setting(uint32_t value)
+    {
+        setting_.bitcoin.target_timespan_seconds = value;
+    }
+
+    /**
+     * Get the value of the bitcoin.retarget_proof_of_work_limit setting.
+     */
+    virtual uint32_t get_bitcoin_retarget_proof_of_work_limit_setting() const
+    {
+        return setting_.bitcoin.retarget_proof_of_work_limit;
+    }
+
+    /**
+     * Set the value of the bitcoin.retarget_proof_of_work_limit setting.
+     */
+    virtual void set_bitcoin_retarget_proof_of_work_limit_setting(uint32_t value)
+    {
+        setting_.bitcoin.retarget_proof_of_work_limit = value;
+    }
+
+    /**
+     * Get the value of the bitcoin.no_retarget_proof_of_work_limit setting.
+     */
+    virtual uint32_t get_bitcoin_no_retarget_proof_of_work_limit_setting() const
+    {
+        return setting_.bitcoin.no_retarget_proof_of_work_limit;
+    }
+
+    /**
+     * Set the value of the bitcoin.no_retarget_proof_of_work_limit setting.
+     */
+    virtual void set_bitcoin_no_retarget_proof_of_work_limit_setting(uint32_t value)
+    {
+        setting_.bitcoin.no_retarget_proof_of_work_limit = value;
+    }
+
+    /**
+     * Get the value of the bitcoin.min_timespan setting.
+     */
+    virtual uint32_t get_bitcoin_min_timespan_setting() const
+    {
+        return setting_.bitcoin.min_timespan;
+    }
+
+    /**
+     * Set the value of the bitcoin.min_timespan setting.
+     */
+    virtual void set_bitcoin_min_timespan_setting(uint32_t value)
+    {
+        setting_.bitcoin.min_timespan = value;
+    }
+
+    /**
+     * Get the value of the bitcoin.max_timespan setting.
+     */
+    virtual uint32_t get_bitcoin_max_timespan_setting() const
+    {
+        return setting_.bitcoin.max_timespan;
+    }
+
+    /**
+     * Set the value of the bitcoin.max_timespan setting.
+     */
+    virtual void set_bitcoin_max_timespan_setting(uint32_t value)
+    {
+        setting_.bitcoin.max_timespan = value;
+    }
+
+    /**
+     * Get the value of the bitcoin.retargeting_interval setting.
+     */
+    virtual size_t get_bitcoin_retargeting_interval_setting() const
+    {
+        return setting_.bitcoin.retargeting_interval;
+    }
+
+    /**
+     * Set the value of the bitcoin.retargeting_interval setting.
+     */
+    virtual void set_bitcoin_retargeting_interval_setting(size_t value)
+    {
+        setting_.bitcoin.retargeting_interval = value;
+    }
+
 protected:
 
     /**
@@ -812,10 +1022,39 @@ private:
             bc::config::sodium client_private_key;
         } server;
 
+        struct bitcoin
+        {
+            bitcoin()
+              : retargeting_factor(),
+                target_spacing_seconds(),
+                easy_spacing_seconds(),
+                timestamp_future_seconds(),
+                target_timespan_seconds(),
+                retarget_proof_of_work_limit(),
+                no_retarget_proof_of_work_limit(),
+                min_timespan(),
+                max_timespan(),
+                retargeting_interval()
+            {
+            }
+
+            uint32_t retargeting_factor;
+            uint32_t target_spacing_seconds;
+            uint32_t easy_spacing_seconds;
+            uint32_t timestamp_future_seconds;
+            uint32_t target_timespan_seconds;
+            uint32_t retarget_proof_of_work_limit;
+            uint32_t no_retarget_proof_of_work_limit;
+            uint32_t min_timespan;
+            uint32_t max_timespan;
+            size_t retargeting_interval;
+        } bitcoin;
+
         setting()
           : wallet(),
             network(),
-            server()
+            server(),
+            bitcoin()
         {
         }
     } setting_;

--- a/include/bitcoin/explorer/impl/utility.ipp
+++ b/include/bitcoin/explorer/impl/utility.ipp
@@ -115,6 +115,29 @@ void write_file(std::ostream& output, const std::string& path,
     }
 }
 
+template<typename Command>
+void populate_bitcoin_settings(bc::settings& bitcoin_settings,
+    const Command& command) {
+    bitcoin_settings.retargeting_factor =
+        command.get_bitcoin_retargeting_factor_setting();
+    bitcoin_settings.target_spacing_seconds =
+        command.get_bitcoin_target_spacing_seconds_setting();
+    bitcoin_settings.easy_spacing_seconds =
+        command.get_bitcoin_easy_spacing_seconds_setting();
+    bitcoin_settings.timestamp_future_seconds =
+        command.get_bitcoin_timestamp_future_seconds_setting();
+    bitcoin_settings.target_timespan_seconds =
+        command.get_bitcoin_target_timespan_seconds_setting();
+    bitcoin_settings.retarget_proof_of_work_limit =
+        command.get_bitcoin_retarget_proof_of_work_limit_setting();
+    bitcoin_settings.no_retarget_proof_of_work_limit =
+        command.get_bitcoin_no_retarget_proof_of_work_limit_setting();
+    bitcoin_settings.min_timespan = command.get_bitcoin_min_timespan_setting();
+    bitcoin_settings.max_timespan = command.get_bitcoin_max_timespan_setting();
+    bitcoin_settings.retargeting_interval =
+        command.get_bitcoin_retargeting_interval_setting();
+}
+
 } // namespace explorer
 } // namespace libbitcoin
 

--- a/include/bitcoin/explorer/utility.hpp
+++ b/include/bitcoin/explorer/utility.hpp
@@ -121,6 +121,16 @@ void write_file(std::ostream& output, const std::string& path,
     const Instance& instance, bool terminate=true);
 
 /**
+ * Populate the bc::settings object with settings from command.
+ * @param      Command           The type of the command.
+ * @param[out] bitcoin_settings  The bitcoin settings.
+ * @param[in]  command           The command.
+ */
+template<typename Command>
+void populate_bitcoin_settings(bc::settings& bitcoin_settings,
+    const Command& command);
+
+/**
  * Get the connection settings for the configured network.
  * @param    command  The command.
  * @returns           A structure containing the connection settings.

--- a/model/generate.xml
+++ b/model/generate.xml
@@ -61,6 +61,19 @@
     <setting name="client_private_key" type="sodium" description="The Z85-encoded private key of the client." />
   </configuration>
 
+  <configuration section="bitcoin">
+    <setting name="retargeting_factor" type="uint32_t" default="4" description="The URL of the Libbitcoin server." />
+    <setting name="target_spacing_seconds" type="uint32_t" default="600" description="The URL of the Libbitcoin server." />
+    <setting name="easy_spacing_seconds" type="uint32_t" default="1200" description="The URL of the Libbitcoin server." />
+    <setting name="timestamp_future_seconds" type="uint32_t" default="7200" description="The URL of the Libbitcoin server." />
+    <setting name="target_timespan_seconds" type="uint32_t" default="1209600" description="The URL of the Libbitcoin server." />
+    <setting name="retarget_proof_of_work_limit" type="uint32_t" default="486604799" description="The URL of the Libbitcoin server." />
+    <setting name="no_retarget_proof_of_work_limit" type="uint32_t" default="545259519" description="The URL of the Libbitcoin server." />
+    <setting name="min_timespan" type="uint32_t" default="302400" description="The URL of the Libbitcoin server." />
+    <setting name="max_timespan" type="uint32_t" default="4838400" description="The URL of the Libbitcoin server." />
+    <setting name="retargeting_interval" type="size_t" default="2016" description="The URL of the Libbitcoin server." />
+  </configuration>
+
   <!-- General resources. -->
 
   <resource>

--- a/src/commands/fetch-balance.cpp
+++ b/src/commands/fetch-balance.cpp
@@ -26,6 +26,7 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/display.hpp>
 #include <bitcoin/explorer/prop_tree.hpp>
+#include <bitcoin/explorer/utility.hpp>
 
 namespace libbitcoin {
 namespace explorer {
@@ -41,7 +42,9 @@ console_result fetch_balance::invoke(std::ostream& output, std::ostream& error)
     const auto& address = get_payment_address_argument();
     const auto connection = get_connection(*this);
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-header.cpp
+++ b/src/commands/fetch-header.cpp
@@ -42,7 +42,9 @@ console_result fetch_header::invoke(std::ostream& output, std::ostream& error)
     const encoding& encoding = get_format_option();
     const auto connection = get_connection(*this);
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-height.cpp
+++ b/src/commands/fetch-height.cpp
@@ -63,7 +63,9 @@ console_result fetch_height::invoke(std::ostream& output, std::ostream& error)
         }
     }
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-history.cpp
+++ b/src/commands/fetch-history.cpp
@@ -25,6 +25,7 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/display.hpp>
 #include <bitcoin/explorer/prop_tree.hpp>
+#include <bitcoin/explorer/utility.hpp>
 
 namespace libbitcoin {
 namespace explorer {
@@ -47,7 +48,9 @@ console_result fetch_history::invoke(std::ostream& output, std::ostream& error)
     const auto& address = get_payment_address_argument();
     const auto connection = get_connection(*this);
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-stealth.cpp
+++ b/src/commands/fetch-stealth.cpp
@@ -25,6 +25,7 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/display.hpp>
 #include <bitcoin/explorer/prop_tree.hpp>
+#include <bitcoin/explorer/utility.hpp>
 
 namespace libbitcoin {
 namespace explorer {
@@ -54,7 +55,9 @@ console_result fetch_stealth::invoke(std::ostream& output, std::ostream& error)
         return console_result::failure;
     }
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-tx-index.cpp
+++ b/src/commands/fetch-tx-index.cpp
@@ -42,7 +42,9 @@ console_result fetch_tx_index::invoke(std::ostream& output, std::ostream& error)
     const auto& hash = get_hash_argument();
     const auto connection = get_connection(*this);
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-tx.cpp
+++ b/src/commands/fetch-tx.cpp
@@ -41,7 +41,9 @@ console_result fetch_tx::invoke(std::ostream& output, std::ostream& error)
     const auto& hash = get_hash_argument();
     const auto connection = get_connection(*this);
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-utxo.cpp
+++ b/src/commands/fetch-utxo.cpp
@@ -25,6 +25,7 @@
 #include <bitcoin/explorer/define.hpp>
 #include <bitcoin/explorer/display.hpp>
 #include <bitcoin/explorer/config/algorithm.hpp>
+#include <bitcoin/explorer/utility.hpp>
 
 namespace libbitcoin {
 namespace explorer {
@@ -42,7 +43,9 @@ console_result fetch_utxo::invoke(std::ostream& output, std::ostream& error)
     const auto& address = get_payment_address_argument();
     const auto connection = get_connection(*this);
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/send-tx-node.cpp
+++ b/src/commands/send-tx-node.cpp
@@ -129,7 +129,9 @@ console_result send_tx_node::invoke(std::ostream& output, std::ostream& error)
     // Network operations.
     //-------------------------------------------------------------------------
 
-    p2p network(settings);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    p2p network(settings, bitcoin_settings);
     callback_state state(error, output);
     message::transaction tx(transaction);
 

--- a/src/commands/send-tx-p2p.cpp
+++ b/src/commands/send-tx-p2p.cpp
@@ -126,7 +126,9 @@ console_result send_tx_p2p::invoke(std::ostream& output, std::ostream& error)
     // Network operations.
     //-------------------------------------------------------------------------
 
-    p2p network(settings);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    p2p network(settings, bitcoin_settings);
     callback_state state(error, output);
     message::transaction tx(transaction);
 

--- a/src/commands/send-tx.cpp
+++ b/src/commands/send-tx.cpp
@@ -38,7 +38,9 @@ console_result send_tx::invoke(std::ostream& output, std::ostream& error)
     const auto& transaction = get_transaction_argument();
     const auto connection = get_connection(*this);
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/subscribe-block.cpp
+++ b/src/commands/subscribe-block.cpp
@@ -51,7 +51,9 @@ console_result subscribe_block::invoke(std::ostream& output, std::ostream& error
         state.output(property_tree(bc::config::header(block.header())));
     };
 
-    obelisk_client client(0, 0);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(0, 0, bitcoin_settings);
     if (!client.subscribe_block(connection.block_server, on_block))
     {
         output << BX_SUBSCRIBE_BLOCK_FAILED << std::endl;

--- a/src/commands/subscribe-tx.cpp
+++ b/src/commands/subscribe-tx.cpp
@@ -51,7 +51,9 @@ console_result subscribe_tx::invoke(std::ostream& output, std::ostream& error)
         state.output(encode_base16(tx.hash()));
     };
 
-    obelisk_client client(0, 0);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(0, 0, bitcoin_settings);
     if (!client.subscribe_transaction(connection.transaction_server,
         on_transaction))
     {

--- a/src/commands/validate-tx.cpp
+++ b/src/commands/validate-tx.cpp
@@ -40,7 +40,9 @@ console_result validate_tx::invoke(std::ostream& output,
     const auto& transaction = get_transaction_argument();
     const auto connection = get_connection(*this);
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/watch-address.cpp
+++ b/src/commands/watch-address.cpp
@@ -51,7 +51,9 @@ console_result watch_address::invoke(std::ostream& output, std::ostream& error)
     const auto connection = get_connection(*this);
     const auto duration = get_duration_option();
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {

--- a/src/commands/watch-stealth.cpp
+++ b/src/commands/watch-stealth.cpp
@@ -63,7 +63,9 @@ console_result watch_stealth::invoke(std::ostream& output, std::ostream& error)
         return console_result::failure;
     }
 
-    obelisk_client client(connection);
+    bc::settings bitcoin_settings;
+    populate_bitcoin_settings(bitcoin_settings, *this);
+    obelisk_client client(connection, bitcoin_settings);
 
     if (!client.connect(connection))
     {


### PR DESCRIPTION
I'm planning to extend the parser once all constants have been moved into `bc::settings`.