### PR TITLE
Revert "propagate new bc::settings class"

### DIFF
--- a/src/commands/fetch-balance.cpp
+++ b/src/commands/fetch-balance.cpp
@@ -42,9 +42,7 @@ console_result fetch_balance::invoke(std::ostream& output, std::ostream& error)
     const auto& address = get_payment_address_argument();
     const auto connection = get_connection(*this);
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-header.cpp
+++ b/src/commands/fetch-header.cpp
@@ -42,9 +42,7 @@ console_result fetch_header::invoke(std::ostream& output, std::ostream& error)
     const encoding& encoding = get_format_option();
     const auto connection = get_connection(*this);
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-height.cpp
+++ b/src/commands/fetch-height.cpp
@@ -63,9 +63,7 @@ console_result fetch_height::invoke(std::ostream& output, std::ostream& error)
         }
     }
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-history.cpp
+++ b/src/commands/fetch-history.cpp
@@ -48,9 +48,7 @@ console_result fetch_history::invoke(std::ostream& output, std::ostream& error)
     const auto& address = get_payment_address_argument();
     const auto connection = get_connection(*this);
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-stealth.cpp
+++ b/src/commands/fetch-stealth.cpp
@@ -55,9 +55,7 @@ console_result fetch_stealth::invoke(std::ostream& output, std::ostream& error)
         return console_result::failure;
     }
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-tx-index.cpp
+++ b/src/commands/fetch-tx-index.cpp
@@ -42,9 +42,7 @@ console_result fetch_tx_index::invoke(std::ostream& output, std::ostream& error)
     const auto& hash = get_hash_argument();
     const auto connection = get_connection(*this);
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-tx.cpp
+++ b/src/commands/fetch-tx.cpp
@@ -41,9 +41,7 @@ console_result fetch_tx::invoke(std::ostream& output, std::ostream& error)
     const auto& hash = get_hash_argument();
     const auto connection = get_connection(*this);
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/fetch-utxo.cpp
+++ b/src/commands/fetch-utxo.cpp
@@ -43,9 +43,7 @@ console_result fetch_utxo::invoke(std::ostream& output, std::ostream& error)
     const auto& address = get_payment_address_argument();
     const auto connection = get_connection(*this);
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/send-tx-node.cpp
+++ b/src/commands/send-tx-node.cpp
@@ -129,9 +129,7 @@ console_result send_tx_node::invoke(std::ostream& output, std::ostream& error)
     // Network operations.
     //-------------------------------------------------------------------------
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    p2p network(settings, bitcoin_settings);
+    p2p network(settings);
     callback_state state(error, output);
     message::transaction tx(transaction);
 

--- a/src/commands/send-tx-p2p.cpp
+++ b/src/commands/send-tx-p2p.cpp
@@ -126,9 +126,7 @@ console_result send_tx_p2p::invoke(std::ostream& output, std::ostream& error)
     // Network operations.
     //-------------------------------------------------------------------------
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    p2p network(settings, bitcoin_settings);
+    p2p network(settings);
     callback_state state(error, output);
     message::transaction tx(transaction);
 

--- a/src/commands/send-tx.cpp
+++ b/src/commands/send-tx.cpp
@@ -38,9 +38,7 @@ console_result send_tx::invoke(std::ostream& output, std::ostream& error)
     const auto& transaction = get_transaction_argument();
     const auto connection = get_connection(*this);
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/subscribe-block.cpp
+++ b/src/commands/subscribe-block.cpp
@@ -51,9 +51,7 @@ console_result subscribe_block::invoke(std::ostream& output, std::ostream& error
         state.output(property_tree(bc::config::header(block.header())));
     };
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(0, 0, bitcoin_settings);
+    obelisk_client client(0, 0);
     if (!client.subscribe_block(connection.block_server, on_block))
     {
         output << BX_SUBSCRIBE_BLOCK_FAILED << std::endl;

--- a/src/commands/subscribe-tx.cpp
+++ b/src/commands/subscribe-tx.cpp
@@ -51,9 +51,7 @@ console_result subscribe_tx::invoke(std::ostream& output, std::ostream& error)
         state.output(encode_base16(tx.hash()));
     };
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(0, 0, bitcoin_settings);
+    obelisk_client client(0, 0);
     if (!client.subscribe_transaction(connection.transaction_server,
         on_transaction))
     {

--- a/src/commands/validate-tx.cpp
+++ b/src/commands/validate-tx.cpp
@@ -40,9 +40,7 @@ console_result validate_tx::invoke(std::ostream& output,
     const auto& transaction = get_transaction_argument();
     const auto connection = get_connection(*this);
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/watch-address.cpp
+++ b/src/commands/watch-address.cpp
@@ -51,9 +51,7 @@ console_result watch_address::invoke(std::ostream& output, std::ostream& error)
     const auto connection = get_connection(*this);
     const auto duration = get_duration_option();
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {

--- a/src/commands/watch-stealth.cpp
+++ b/src/commands/watch-stealth.cpp
@@ -63,9 +63,7 @@ console_result watch_stealth::invoke(std::ostream& output, std::ostream& error)
         return console_result::failure;
     }
 
-    bc::settings bitcoin_settings;
-    populate_bitcoin_settings(bitcoin_settings, *this);
-    obelisk_client client(connection, bitcoin_settings);
+    obelisk_client client(connection);
 
     if (!client.connect(connection))
     {


### PR DESCRIPTION
This reverts commit 3c6cc505e037e64df5c6e9138e311acd29673aad.

Reason: https://github.com/libbitcoin/libbitcoin/pull/1013