### PR TITLE
Add base16 encoding to output formats.

### DIFF
--- a/include/bitcoin/explorer/define.hpp
+++ b/include/bitcoin/explorer/define.hpp
@@ -104,7 +104,8 @@ enum class encoding_engine
 {
     info,
     json,
-    xml
+    xml,
+    data
 };
 
 } // namespace explorer

--- a/src/commands/fetch-block.cpp
+++ b/src/commands/fetch-block.cpp
@@ -53,16 +53,22 @@ console_result fetch_block::invoke(std::ostream& output, std::ostream& error)
 
     callback_state state(error, output, encoding);
 
-    // This enables json-style array formatting.
-    const auto json = encoding == encoding_engine::json;
-
-    auto on_done = [&state, json](const code& ec,
+    auto on_done = [&state, encoding](const code& ec,
         const chain::block& block)
     {
         if (!state.succeeded(ec))
             return;
 
-        state.output(property_tree(block, json));
+        if (encoding == encoding_engine::data)
+        {
+            state.output(encode_base16(block.to_data()));
+        }
+        else
+        {
+            // This enables json-style array formatting.
+            const auto json = encoding == encoding_engine::json;
+            state.output(property_tree(block, json));
+        }
     };
 
     // Height is ignored if both are specified.

--- a/src/commands/fetch-tx.cpp
+++ b/src/commands/fetch-tx.cpp
@@ -52,15 +52,21 @@ console_result fetch_tx::invoke(std::ostream& output, std::ostream& error)
 
     callback_state state(error, output, encoding);
 
-    // This enables json-style array formatting.
-    const auto json = encoding == encoding_engine::json;
-
-    auto on_done = [&state, json](const code& ec, const tx_type& tx)
+    auto on_done = [&state, encoding](const code& ec, const tx_type& tx)
     {
         if (!state.succeeded(ec))
             return;
 
-        state.output(property_tree(tx, json));
+        if (encoding == encoding_engine::data)
+        {
+            state.output(encode_base16(tx.to_data()));
+        }
+        else
+        {
+            // This enables json-style array formatting.
+            const auto json = encoding == encoding_engine::json;
+            state.output(property_tree(tx, json));
+        }
     };
 
     if (witness)

--- a/src/config/encoding.cpp
+++ b/src/config/encoding.cpp
@@ -34,6 +34,7 @@ using namespace po;
 static auto encoding_info = "info";
 static auto encoding_json = "json";
 static auto encoding_xml = "xml";
+static auto encoding_data = "data";
 
 encoding::encoding()
   : encoding(encoding_engine::info)
@@ -71,6 +72,8 @@ std::istream& operator>>(std::istream& input, encoding& argument)
         argument.value_ = encoding_engine::json;
     else if (text == encoding_xml)
         argument.value_ = encoding_engine::xml;
+    else if (text == encoding_data)
+        argument.value_ = encoding_engine::data;
     else
     {
         BOOST_THROW_EXCEPTION(invalid_option_value(text));
@@ -93,6 +96,9 @@ std::ostream& operator<<(std::ostream& output, const encoding& argument)
             break;
         case encoding_engine::xml:
             value = encoding_xml;
+            break;
+        case encoding_engine::data:
+            value = encoding_data;
             break;
         default:
             BITCOIN_ASSERT_MSG(false, "Unexpected encoding value.");

--- a/test/commands/fetch-tx.cpp
+++ b/test/commands/fetch-tx.cpp
@@ -133,6 +133,9 @@ BOOST_AUTO_TEST_SUITE(fetch_tx__invoke)
 "    version 1\n" \
 "}\n"
 
+#define FETCH_TX_TESTNET_SERIALIZED_DATA \
+"0100000001c422ec82824d97c2894905ab8fcb73dbc0e16ee44797e1e1967db42cd9564218010000006c493046022100f18c97457e00c491d3eed5d9c2c5da33398595adf2708a07f677fb1e3eeeccba022100dc5c886192a9af7a28ab7689e766f3be6b01b61a4c675c97e8d2c99cd8b9d1320121037928262812eb9e73b9ca8039f8023db84b0a86c5caf6bc28cefb85e9943684acffffffff02a530ed10000000001976a91405e18e90cf803e17b9fa70abd2ad931389cc2cd488acd533591c000000001976a9148f3441dd22b15a30dcde56f9b3de7a61b7a3a74088ac00000000\n"
+
 BOOST_AUTO_TEST_CASE(fetch_tx__invoke__mainnet_satoshis_words_tx_info__okay_output)
 {
     BX_DECLARE_CLIENT_COMMAND(fetch_tx);
@@ -167,6 +170,15 @@ BOOST_AUTO_TEST_CASE(fetch_tx__invoke__testnet_tx_info__okay_output)
     command.set_hash_argument({ FETCH_TX_TESTNET_TX_HASH });
     BX_REQUIRE_OKAY(command.invoke(output, error));
     BX_REQUIRE_OUTPUT(FETCH_TX_TESTNET_TX_INFO);
+}
+
+BOOST_AUTO_TEST_CASE(fetch_tx__invoke__testnet_tx_data__okay_output)
+{
+    BX_DECLARE_CLIENT_TESTNET_COMMAND(fetch_tx);
+    command.set_format_option({ "data" });
+    command.set_hash_argument({ FETCH_TX_TESTNET_TX_HASH });
+    BX_REQUIRE_OKAY(command.invoke(output, error));
+    BX_REQUIRE_OUTPUT(FETCH_TX_TESTNET_SERIALIZED_DATA);
 }
 
 // Requires server of at least v3.4.


### PR DESCRIPTION
This adds a 'data' encoding intended for outputting serialized tx and block data.